### PR TITLE
show window when conversation started invoked

### DIFF
--- a/src/qml/components/MessagesService.qml
+++ b/src/qml/components/MessagesService.qml
@@ -19,7 +19,6 @@ Item {
              '  </interface>\n'
 
         function startConversation(localUid, remoteUid, show) {
-            console.log("DEBUG " + localUid + " " + remoteUid + " " + show)
             rootObject.startConversation(localUid, remoteUid, show)
         }
     }

--- a/src/qml/glacier-messages.qml
+++ b/src/qml/glacier-messages.qml
@@ -74,7 +74,9 @@ ApplicationWindow {
         id: messageService
 
         onStartConversation: {
+            console.log("start conversation: " + localUid + ", " + remoteUid + ", " + show)
             showConversation(localUid,remoteUid)
+            app.show()
         }
     }
 


### PR DESCRIPTION
I have managed to open chat from notification

Steps to reproduce:

Simulate some chat:
https://gist.github.com/jmlich/d66cd4c6bf46ba1bc279a3201cc76a5a

Add notification:
```
arg_account="/org/freedesktop/Telepathy/Account/ring/tel/account0"
arg_target_id="07-3242325"
notificationtool -o add --application="Messages" --urgency=2 --icon="icon-lock-sms" "+420123456789" "Never gonna give you up, Never gonna let you down, Never gonna run around and desert you, Never gonna make you cry, Never gonna say goodbye, Never gonna tell a lie and hurt you" \
  --action="default org.nemomobile.qmlmessages / org.sailfishos.Messages startConversation $arg_account $arg_target_id false"
```

P.S. You just got Rick rolled